### PR TITLE
Add "description" property to enemies.

### DIFF
--- a/editor.lua
+++ b/editor.lua
@@ -1473,7 +1473,15 @@ function editor_draw()
 				if editentities then
 					if editenemies then
 						if enemies[tile] then
-							properprint(enemies[tile], 3*scale, 205*scale)
+							if enemiesdata[enemies[tile]].description then
+								local newstring = enemies[tile] .. " - " .. enemiesdata[enemies[tile]].description
+								if string.len(newstring) > 49 then
+									newstring = string.sub(newstring, 1, 49) .. "|" .. string.sub(newstring, 50, 98)
+								end
+								properprint(newstring, 3*scale, 205*scale)
+							else
+								properprint(enemies[tile], 3*scale, 205*scale)
+							end
 						end
 					else
 						local ent = getentityhighlight(mouse.getX(), mouse.getY())

--- a/enemies.lua
+++ b/enemies.lua
@@ -1,6 +1,8 @@
 function enemies_load()
 	defaultvalues = {quadcount=1, quadno=1}
-
+	
+	nobasevalues = {"description"} --values that aren't loaded from base
+	
 	enemiesdata = {}
 	enemies = {}
 	
@@ -169,7 +171,18 @@ function usebase(t)
 	local r = {}
 	
 	for i, v in pairs(t) do
-		r[i] = v
+		check = true
+		for j in pairs(nobasevalues) do
+			if i == v then
+				check = false
+				break
+			end
+		end
+		if check then
+			if i ~= "description" then
+				r[i] = v
+			end
+		end
 	end
 	
 	return r


### PR DESCRIPTION
The description is shown while hovering the enemy in the enemy list if the enemy has a description.
![image](https://user-images.githubusercontent.com/14860275/48923718-48096f00-eeb1-11e8-8bfd-fe8897f6976b.png)
Question before merging: what kind of descriptions should we put on the default enemies? No description, brand new descriptions or do we put the ones from 1.6?