### PR TITLE
snap: Migrate to love stage snap and mischellaneous* fixes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,10 +54,13 @@ parts:
     source: .
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version \
-        "$(git describe --always --dirty --tags)"
+
+      snap_version="$(git describe --always --dirty --tags)"
+      snapcraftctl set-version "${snap_version}"
 
     plugin: dump
+    build-packages:
+    - git
     organize:
       '*': mari0-ce/
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,7 @@ parts:
       snapcraftctl pull
 
       snap_version="$(git describe --always --dirty --tags)"
+      printf 'override-pull: Snap version set to "%s".\n' "${snap_version}" 1>&2
       snapcraftctl set-version "${snap_version}"
 
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,17 +64,19 @@ parts:
   love:
     plugin: nil
     stage-snaps:
-    - love-brlin
+    - love
 
 apps:
   mari0-ce:
     adapter: full
     command: bin/love $SNAP/mari0-ce
     command-chain:
-    - bin/workaround-snap-arch-triplet-launch
     - bin/locales-launch
     - bin/love-launch
     - bin/mari0-ce-launch
+    environment:
+      # Workaround libpulsecommon library runtime dependency
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio
 
 plugs:
   # For snaps with a graphical user interface:
@@ -102,3 +104,9 @@ plugs:
 
   # For DLC download feature
   network:
+
+layout:
+  # Fix characters not in non-ASCII range not displayed in the window's
+  # title bar
+  /usr/share/X11/locale:
+    bind: $SNAP/usr/share/X11/locale


### PR DESCRIPTION
The original love-brlin stage snap is renamed to love and thus obsoleted, this patch does the migration.

[*](https://www.youtube.com/watch?v=22vbhTi1ieI)